### PR TITLE
feat: removed cjs wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "type": "opencollective",
     "url": "https://opencollective.com/webpack"
   },
-  "main": "dist/cjs.js",
-  "types": "types/cjs.d.ts",
+  "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">= 12.13.0"
   },
   "scripts": {
     "start": "npm run build -- -w",
-    "clean": "del-cli dist",
+    "clean": "del-cli dist types",
     "prebuild": "npm run clean",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.ts\" --write",
     "build:code": "cross-env NODE_ENV=production babel src -d dist --copy-files",

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,1 +1,0 @@
-module.exports = require("./index").default;

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
-import os from "os";
+const os = require("os");
 
-import { validate } from "schema-utils";
-import serialize from "serialize-javascript";
-import { Worker } from "jest-worker";
+const { validate } = require("schema-utils");
+const serialize = require("serialize-javascript");
+const { Worker } = require("jest-worker");
 
-import schema from "./options.json";
+const schema = require("./options.json");
 
-import { htmlMinifierTerser, throttleAll } from "./utils";
-import { minify as minifyFn } from "./minify";
+const { htmlMinifierTerser, throttleAll } = require("./utils");
+const { minify } = require("./minify");
 
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
@@ -378,7 +378,7 @@ class HtmlMinimizerPlugin {
           try {
             output = await (getWorker
               ? getWorker().transform(serialize(options))
-              : minifyFn(options));
+              : minify(options));
           } catch (error) {
             compilation.errors.push(
               /** @type {WebpackError} */
@@ -475,4 +475,4 @@ class HtmlMinimizerPlugin {
 
 HtmlMinimizerPlugin.htmlMinifierTerser = htmlMinifierTerser;
 
-export default HtmlMinimizerPlugin;
+module.exports = HtmlMinimizerPlugin;

--- a/src/minify.js
+++ b/src/minify.js
@@ -63,5 +63,4 @@ async function transform(options) {
   return minify(evaluatedOptions);
 }
 
-module.exports.minify = minify;
-module.exports.transform = transform;
+module.exports = { minify, transform };

--- a/src/utils.js
+++ b/src/utils.js
@@ -102,4 +102,4 @@ async function htmlMinifierTerser(input, minimizerOptions = {}) {
   return { code: result };
 }
 
-export { throttleAll, htmlMinifierTerser };
+module.exports = { throttleAll, htmlMinifierTerser };

--- a/test/cjs.test.js
+++ b/test/cjs.test.js
@@ -1,8 +1,0 @@
-import src from "../src";
-import cjs from "../src/cjs";
-
-describe("CJS", () => {
-  it("should export loader", () => {
-    expect(cjs).toEqual(src);
-  });
-});

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -1,2 +1,0 @@
-declare const _exports: typeof import("./index").default;
-export = _exports;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,80 +1,4 @@
-export default HtmlMinimizerPlugin;
-export type Schema = import("schema-utils/declarations/validate").Schema;
-export type Compiler = import("webpack").Compiler;
-export type Compilation = import("webpack").Compilation;
-export type WebpackError = import("webpack").WebpackError;
-export type Asset = import("webpack").Asset;
-export type JestWorker = import("jest-worker").Worker;
-export type HtmlMinifierTerserOptions =
-  import("./utils.js").HtmlMinifierTerserOptions;
-export type Rule = RegExp | string;
-export type Rules = Rule[] | Rule;
-export type MinimizedResult = {
-  code: string;
-  errors?: unknown[] | undefined;
-  warnings?: unknown[] | undefined;
-};
-export type Input = {
-  [file: string]: string;
-};
-export type CustomOptions = {
-  [key: string]: any;
-};
-export type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
-export type MinimizerOptions<T> = InferDefaultType<T> | undefined;
-export type MinimizerImplementation<T> = (
-  input: Input,
-  minimizerOptions?: MinimizerOptions<T>
-) => Promise<MinimizedResult>;
-export type Minimizer<T> = {
-  implementation: MinimizerImplementation<T>;
-  options?: MinimizerOptions<T> | undefined;
-};
-export type InternalOptions<T> = {
-  name: string;
-  input: string;
-  minimizer: T extends any[]
-    ? { [P in keyof T]: Minimizer<T[P]> }
-    : Minimizer<T>;
-};
-export type InternalResult = {
-  code: string;
-  warnings: Array<any>;
-  errors: Array<any>;
-};
-export type MinimizerWorker<T> = Worker & {
-  transform: (options: string) => InternalResult;
-  minify: (options: InternalOptions<T>) => InternalResult;
-};
-export type Parallel = undefined | boolean | number;
-export type BasePluginOptions = {
-  test?: Rules | undefined;
-  include?: Rules | undefined;
-  exclude?: Rules | undefined;
-  parallel?: Parallel;
-};
-export type InternalPluginOptions<T> = BasePluginOptions & {
-  minimizer: T extends any[]
-    ? { [P in keyof T]: Minimizer<T[P]> }
-    : Minimizer<T>;
-};
-export type DefinedDefaultMinimizerAndOptions<T> =
-  T extends import("html-minifier-terser").Options
-    ? {
-        minify?: MinimizerImplementation<T> | undefined;
-        minimizerOptions?: MinimizerOptions<T> | undefined;
-      }
-    : T extends any[]
-    ? {
-        minify: { [P in keyof T]: MinimizerImplementation<T[P]> };
-        minimizerOptions?:
-          | { [P_1 in keyof T]?: MinimizerOptions<T[P_1]> }
-          | undefined;
-      }
-    : {
-        minify: MinimizerImplementation<T>;
-        minimizerOptions?: MinimizerOptions<T> | undefined;
-      };
+export = HtmlMinimizerPlugin;
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
 /** @typedef {import("webpack").Compilation} Compilation */
@@ -209,7 +133,108 @@ declare class HtmlMinimizerPlugin<T = import("html-minifier-terser").Options> {
   apply(compiler: Compiler): void;
 }
 declare namespace HtmlMinimizerPlugin {
-  export { htmlMinifierTerser };
+  export {
+    htmlMinifierTerser,
+    Schema,
+    Compiler,
+    Compilation,
+    WebpackError,
+    Asset,
+    JestWorker,
+    HtmlMinifierTerserOptions,
+    Rule,
+    Rules,
+    MinimizedResult,
+    Input,
+    CustomOptions,
+    InferDefaultType,
+    MinimizerOptions,
+    MinimizerImplementation,
+    Minimizer,
+    InternalOptions,
+    InternalResult,
+    MinimizerWorker,
+    Parallel,
+    BasePluginOptions,
+    InternalPluginOptions,
+    DefinedDefaultMinimizerAndOptions,
+  };
 }
-import { Worker } from "jest-worker";
+type Compiler = import("webpack").Compiler;
+type BasePluginOptions = {
+  test?: Rules | undefined;
+  include?: Rules | undefined;
+  exclude?: Rules | undefined;
+  parallel?: Parallel;
+};
+type DefinedDefaultMinimizerAndOptions<T> =
+  T extends import("html-minifier-terser").Options
+    ? {
+        minify?: MinimizerImplementation<T> | undefined;
+        minimizerOptions?: MinimizerOptions<T> | undefined;
+      }
+    : T extends any[]
+    ? {
+        minify: { [P in keyof T]: MinimizerImplementation<T[P]> };
+        minimizerOptions?:
+          | { [P_1 in keyof T]?: MinimizerOptions<T[P_1]> }
+          | undefined;
+      }
+    : {
+        minify: MinimizerImplementation<T>;
+        minimizerOptions?: MinimizerOptions<T> | undefined;
+      };
 import { htmlMinifierTerser } from "./utils";
+type Schema = import("schema-utils/declarations/validate").Schema;
+type Compilation = import("webpack").Compilation;
+type WebpackError = import("webpack").WebpackError;
+type Asset = import("webpack").Asset;
+type JestWorker = import("jest-worker").Worker;
+type HtmlMinifierTerserOptions = import("./utils.js").HtmlMinifierTerserOptions;
+type Rule = RegExp | string;
+type Rules = Rule[] | Rule;
+type MinimizedResult = {
+  code: string;
+  errors?: unknown[] | undefined;
+  warnings?: unknown[] | undefined;
+};
+type Input = {
+  [file: string]: string;
+};
+type CustomOptions = {
+  [key: string]: any;
+};
+type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
+type MinimizerOptions<T> = InferDefaultType<T> | undefined;
+type MinimizerImplementation<T> = (
+  input: Input,
+  minimizerOptions?: MinimizerOptions<T>
+) => Promise<MinimizedResult>;
+type Minimizer<T> = {
+  implementation: MinimizerImplementation<T>;
+  options?: MinimizerOptions<T> | undefined;
+};
+type InternalOptions<T> = {
+  name: string;
+  input: string;
+  minimizer: T extends any[]
+    ? { [P in keyof T]: Minimizer<T[P]> }
+    : Minimizer<T>;
+};
+type InternalResult = {
+  code: string;
+  warnings: Array<any>;
+  errors: Array<any>;
+};
+type MinimizerWorker<T> = Worker & {
+  transform: (options: string) => InternalResult;
+  minify: (options: InternalOptions<T>) => InternalResult;
+};
+type Parallel = undefined | boolean | number;
+type InternalPluginOptions<T> = BasePluginOptions & {
+  minimizer: T extends any[]
+    ? { [P in keyof T]: Minimizer<T[P]> }
+    : Minimizer<T>;
+};
+import { minify } from "./minify";
+import { Worker } from "jest-worker";


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

removed cjs wrapper and generated types in commonjs format (`export =` and `namespaces` used in types), now you can directly use exported types

### Breaking Changes

Potential yes, but we use babel so our format is commonjs, but types in esm

### Additional Info

No