### PR TITLE
fix: change loaders to rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 
 module.exports = {
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.html$/i,
         type: "asset/resource",


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The webpack config sample seems to contain loaders instead of rules 🤔. 
